### PR TITLE
feat: auto enable tryItOut

### DIFF
--- a/try.js
+++ b/try.js
@@ -49,6 +49,7 @@ function cfgHandle(userCfg) {
       onComplete: () => {
         trySwagger(cfg)
       },
+      tryItOutEnabled: true,
       ...userCfg.swaggerOptions
     },
     redocOptions: [

--- a/try.js
+++ b/try.js
@@ -4,7 +4,7 @@ window.initTry = window.initTry || initTry
 function initTry(userCfg) {
   loadScript(`//cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js`)
     .then(() => loadScript(`//cdn.jsdelivr.net/npm/jquery.scrollto@2.1.2/jquery.scrollTo.min.js`))
-    .then(() => loadScript(`//cdn.jsdelivr.net/npm/swagger-ui-dist@3.25.1/swagger-ui-bundle.js`))
+    .then(() => loadScript(`//cdn.jsdelivr.net/npm/swagger-ui-dist@3.47.1/swagger-ui-bundle.js`))
     .then(() => loadScript(`//cdn.jsdelivr.net/npm/compare-versions@3.6.0/index.min.js`))
     .then(() => {
       const cfg = cfgHandle(userCfg)


### PR DESCRIPTION
Hi there, first off wanted to say what an awesome project this is. Makes it so nice to get the best features from redoc + swagger combined. Thanks a bunch!

So there is a new feature in swagger-ui that automatically starts in tryItOut mode https://github.com/swagger-api/swagger-ui/issues/6528 that was releaseed in 3.41.0.

In order to enable this (reduce extra clicks for the user) I went ahead and bumped the swagger version loaded + enabled it by default.

This way the users are dropped right into the action like so:
<img width="1443" alt="Screen Shot 2021-04-28 at 5 25 12 PM" src="https://user-images.githubusercontent.com/962625/116480332-c1f26f00-a846-11eb-8879-ee5ea4a5bb21.png">


I know this is kind of a drive-by, happy to make any changes needed, but from my quick testing seems like all the other features are working as expected. Thanks again!