### PR TITLE
feat: hide extraneous elements from swagger ui

### DIFF
--- a/try.js
+++ b/try.js
@@ -114,9 +114,6 @@ function initCss() {
         visibility: visible;
         cursor: initial;
       }
-      .opblock-summary * {
-        display: none;
-      }
       .opblock-description-wrapper {
         display: none;
       }

--- a/try.js
+++ b/try.js
@@ -114,6 +114,24 @@ function initCss() {
         visibility: visible;
         cursor: initial;
       }
+      .opblock-summary * {
+        display: none;
+      }
+      .opblock-description-wrapper {
+        display: none;
+      }
+      :not(.live-responses-table).responses-table {
+        display: none;
+      }
+      .responses-inner>div>h4 {
+        display: none;
+      }
+      .try-out {
+        display: none;
+      }
+      .btn.cancel {
+        display: none;
+      }
       .tryBtn {
         margin-right: 10px;
         background-color: #fff;


### PR DESCRIPTION
Hey there, this is based on the previous pull request #10. I went through and set `display: none;` for a bunch of the duplicated data on the swagger side. Not sure if **everyone** would want this, but it works well for me, and wanted to share.

That makes the ui look way less cluttered and more focused imo. Looks like the following:
<img width="1478" alt="Screen Shot 2021-04-28 at 5 29 30 PM" src="https://user-images.githubusercontent.com/962625/116480635-4d6c0000-a847-11eb-8331-a16c49389c11.png">

Happy for any feedback, or if you think this is too specific to my use-case feel free to close this without any explanation. Thanks for an awesome project! 🥂 

For those wanting to just drop this right into `head.styles` on index.html or however they are serving their pages themselves they could use the following.
```css
      .opblock-summary * {
        display: none;
      }
      .opblock-description-wrapper {
        display: none;
      }
      :not(.live-responses-table).responses-table {
        display: none;
      }
      .responses-inner>div>h4 {
        display: none;
      }
      .try-out {
        display: none;
      }
      .btn.cancel {
        display: none;
      }
```