### PR TITLE
fix: show json input even with new hiding rules

### DIFF
--- a/try.js
+++ b/try.js
@@ -117,7 +117,7 @@ function initCss() {
         visibility: visible;
         cursor: initial;
       }
-      .opblock-description-wrapper {
+      .opblock-body > .opblock-description-wrapper {
         display: none;
       }
       :not(.live-responses-table).responses-table {


### PR DESCRIPTION
Seems like it could be possible for the json input to be hidden with the previous rules. I think this fixes it.

Sorry for all the different PRs.

Thanks for supporting.