### PR TITLE
Update jQuery from 3.2.1 to 3.6.0

### DIFF
--- a/try.js
+++ b/try.js
@@ -2,7 +2,7 @@
 window.initTry = window.initTry || initTry
 
 function initTry(userCfg) {
-  loadScript(`//cdn.jsdelivr.net/npm/jquery@3.2.1/dist/jquery.min.js`)
+  loadScript(`//cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js`)
     .then(() => loadScript(`//cdn.jsdelivr.net/npm/jquery.scrollto@2.1.2/jquery.scrollTo.min.js`))
     .then(() => loadScript(`//cdn.jsdelivr.net/npm/swagger-ui-dist@3.48.0/swagger-ui-bundle.js`))
     .then(() => loadScript(`//cdn.jsdelivr.net/npm/compare-versions@3.6.0/index.min.js`))


### PR DESCRIPTION
jQuery 3.2.1 has known vulnerabilities (XSS): https://snyk.io/test/npm/jquery/3.2.1
Update to 3.6.0 to fix this.