### PR TITLE
Fix unwanted swagger box renders on resize

### DIFF
--- a/dist/try.js
+++ b/dist/try.js
@@ -35,7 +35,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
     loadScript("https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js").then(function () {
       return loadScript("https://cdn.jsdelivr.net/npm/jquery.scrollto@2.1.2/jquery.scrollTo.min.js");
     }).then(function () {
-      return loadScript("https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.48.0/swagger-ui-bundle.js");
+      return loadScript("https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js");
     }).then(function () {
       return loadScript("https://cdn.jsdelivr.net/npm/compare-versions@3.6.0/index.min.js");
     }).then(function () {
@@ -123,7 +123,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
     // dom
     $('body').append("\n    <div class=\"swaggerBox\">\n      <div id=\"swagger-ui\"></div>\n    </div>\n  ");
     // swagger-ui.css
-    $('head').append("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.25.1/swagger-ui.css\" />");
+    $('head').append("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css\" />");
     SwaggerUIBundle(swaggerOptions);
   }
   function trySwagger(cfg) {
@@ -226,15 +226,17 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
       }
 
       $opblock.addClass("open");
-      function renderPos() {
+      function renderPos(onlyWhenVisible) {
         var pos = getShadowPos();
-        // Move swagger to the position of swaggerShadow
-        $(".swaggerBox").css({
-          left: "".concat(pos.left),
-          top: "".concat(pos.top),
-          width: "".concat(pos.width),
-          height: oldHeight
-        }).removeClass("hide").addClass('show');
+        if (!onlyWhenVisible || $(".swaggerBox").hasClass("show")) {
+          // Move swagger to the position of swaggerShadow
+          $(".swaggerBox").css({
+            left: "".concat(pos.left),
+            top: "".concat(pos.top),
+            width: "".concat(pos.width),
+            height: oldHeight
+          }).removeClass("hide").addClass('show');
+        }
 
         // Synchronize the size of swaggerShadow to make it as big as swaggerBox
         $(".swaggerShadow").css({
@@ -284,7 +286,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 
     // When changing the browser window size, reset the state of swaggerBox
     $(window).resize(debounce(function () {
-      window.initTry.renderPos();
+      window.initTry.renderPos(true);
     }, 500));
   }
   function isVisible(element) {

--- a/try.js
+++ b/try.js
@@ -287,15 +287,18 @@ function trySwagger(cfg) {
     }
     $opblock.addClass(`open`)
 
-    function renderPos() {
+    function renderPos(onlyWhenVisible) {
       let pos = getShadowPos()
-      // Move swagger to the position of swaggerShadow
-      $(`.swaggerBox`).css({
-        left: `${pos.left}`,
-        top: `${pos.top}`,
-        width: `${pos.width}`,
-        height: oldHeight,
-      }).removeClass(`hide`).addClass('show')
+
+      if (!onlyWhenVisible || $(".swaggerBox").hasClass("show")) {
+        // Move swagger to the position of swaggerShadow
+        $(`.swaggerBox`).css({
+          left: `${pos.left}`,
+          top: `${pos.top}`,
+          width: `${pos.width}`,
+          height: oldHeight,
+        }).removeClass(`hide`).addClass('show')
+      }
   
       // Synchronize the size of swaggerShadow to make it as big as swaggerBox
       $(`.swaggerShadow`).css({
@@ -345,7 +348,7 @@ function trySwagger(cfg) {
 
   // When changing the browser window size, reset the state of swaggerBox
   $(window).resize(debounce(() => {
-    window.initTry.renderPos()
+    window.initTry.renderPos(true)
   }, 500))
 }
 


### PR DESCRIPTION
When you open and close the swagger box and then resize the window from mobile to desktop or the other way around, the swagger box reappears in its last position. This PR fixes the issue.

![output](https://github.com/wll8/redoc-try/assets/27775613/26ff8537-188a-4bc8-a83b-faab292c9151)
