### PR TITLE
fix: do not reopen swagger box with unrelated clicks

### DIFF
--- a/dist/try.js
+++ b/dist/try.js
@@ -35,7 +35,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
     loadScript("https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js").then(function () {
       return loadScript("https://cdn.jsdelivr.net/npm/jquery.scrollto@2.1.2/jquery.scrollTo.min.js");
     }).then(function () {
-      return loadScript("https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.48.0/swagger-ui-bundle.js");
+      return loadScript("https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js");
     }).then(function () {
       return loadScript("https://cdn.jsdelivr.net/npm/compare-versions@3.6.0/index.min.js");
     }).then(function () {
@@ -123,7 +123,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
     // dom
     $('body').append("\n    <div class=\"swaggerBox\">\n      <div id=\"swagger-ui\"></div>\n    </div>\n  ");
     // swagger-ui.css
-    $('head').append("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.25.1/swagger-ui.css\" />");
+    $('head').append("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css\" />");
     SwaggerUIBundle(swaggerOptions);
   }
   function trySwagger(cfg) {
@@ -288,6 +288,9 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
     }, 500));
   }
   function isVisible(element) {
+    if (!element) {
+      return false;
+    }
     var isVisible = true;
     var parentElement = element;
     while (parentElement) {

--- a/try.js
+++ b/try.js
@@ -350,6 +350,10 @@ function trySwagger(cfg) {
 }
 
 function isVisible(element) {
+  if (!element) {
+    return false
+  }
+
   let isVisible = true
   let parentElement = element
   


### PR DESCRIPTION
When you open and close the swagger box and then click somewhere where its last position was, it will reopen. This PR fixes the issue.

![output](https://github.com/wll8/redoc-try/assets/27775613/2adc4d44-962e-4556-8e74-7885cc56b348)
